### PR TITLE
(u) Add support to configure meta-router for single outlet

### DIFF
--- a/projects/controller/src/lib/meta-router-config.ts
+++ b/projects/controller/src/lib/meta-router-config.ts
@@ -12,7 +12,8 @@ export class MetaRouterConfig {
         readonly routes: IAppConfig[],
         readonly handleNotification: HandleBroadcastNotification,
         readonly frameConfig: FrameConfig = new FrameConfig(),
-        readonly unknownRouteHandling: UnknownRouteHandlingEnum = UnknownRouteHandlingEnum.ThrowError
+        readonly unknownRouteHandling: UnknownRouteHandlingEnum = UnknownRouteHandlingEnum.ThrowError,
+        readonly multipleOutlets: boolean = false
     ) {
         if (outlet === '') {
             throw new Error('Outlet is empty');

--- a/projects/controller/src/lib/meta-router.ts
+++ b/projects/controller/src/lib/meta-router.ts
@@ -1,29 +1,15 @@
-import {
-    Destroyable,
-    EVENT_HASHCHANGE,
-    IConsoleFacade,
-    IMap,
-    MessageBroadcast,
-    MessageBroadcastMetadata,
-    MessageGetCustomFrameConfiguration,
-    MessageGoto,
-    MessageRouted,
-    MessageSetFrameStyles,
-    MessageMetaRouted,
-    MessagingApiBroker,
-    SHELL_NAME
-} from '@microfrontend/common';
-import { UrlHelper } from './url-helper';
-import { MetaRouterConfig } from './meta-router-config';
+import { Destroyable, EVENT_HASHCHANGE, IConsoleFacade, IMap, MessageBroadcast, MessageBroadcastMetadata, MessageGetCustomFrameConfiguration, MessageGoto, MessageMetaRouted, MessageRouted, MessageSetFrameStyles, MessagingApiBroker, SHELL_NAME } from '@microfrontend/common';
 import { AppRoute } from './app-route';
-import { MetaRouteHelper } from './meta-route-helper';
+import { ControllerServiceProvider } from './controller-service-provider';
+import { IControllerServiceProvider } from './controller-service-provider-interface';
+import { IFrameFacade } from './frame-facade-interface';
+import { FramesManager } from './frames-manager';
 import { IHistoryApiFacade } from './history-api-facade-interface';
 import { ILocationFacade } from './location-facade-interface';
-import { FramesManager } from './frames-manager';
-import { IFrameFacade } from './frame-facade-interface';
+import { MetaRouteHelper } from './meta-route-helper';
+import { MetaRouterConfig } from './meta-router-config';
 import { PromiseSingletonDecorator } from './promise-singleton-decorator';
-import { IControllerServiceProvider } from './controller-service-provider-interface';
-import { ControllerServiceProvider } from './controller-service-provider';
+import { UrlHelper } from './url-helper';
 
 /**
  * MetaRouter for routing between micro frontends
@@ -305,7 +291,7 @@ export class MetaRouter {
         const hash = this.locationFacade.getTruncatedHash();
         this.consoleFacade.debug('parseHash(%s) -> %s', outlet, hash);
         if (hash) {
-            return UrlHelper.parseUrl(hash, outlet);
+            return UrlHelper.parseUrl(hash, outlet, this.config.multipleOutlets);
         } else {
             return this.getInitOutletsMap(outlet);
         }

--- a/projects/controller/src/lib/url-helper.ts
+++ b/projects/controller/src/lib/url-helper.ts
@@ -20,7 +20,7 @@ export class UrlHelper {
      * Parse URL into meta routes object
      */
     // tslint:disable-next-line:cyclomatic-complexity
-    public static parseUrl(url: string, defaultOutlet: string): IMap<AppRoute[]> {
+    public static parseUrl(url: string, defaultOutlet: string, multipleOutlets: boolean): IMap<AppRoute[]> {
         type STATE = 'key' | 'value';
 
         let key: string = defaultOutlet;
@@ -56,7 +56,7 @@ export class UrlHelper {
                         this.addAppRoute(result, key, value);
                         key = value = '';
                         state = 'key';
-                    } else if (c === '=') {
+                    } else if (multipleOutlets && c === '=') {
                         key = value;
                         value = '';
                         state = 'value';

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,8 @@ window.addEventListener('load', async () => {
             console.debug('received message from routed app', { tag, data });
         },
         new FrameConfig({ test: 'myConfig' }, {}, { class: 'my-outlet-frame' }),
-        UnknownRouteHandlingEnum.ThrowError
+        UnknownRouteHandlingEnum.ThrowError,
+        false
     );
 
     const router = new MetaRouter(config);


### PR DESCRIPTION
Currently controller lib gets broken as soon as the application running inside iFrame start using query params. 