### PR TITLE
check any state to determine if metaroute is dirty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3956,6 +3956,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "http://repo.eb.lan.at:80/artifactory/api/npm/npm-repo/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -7057,6 +7068,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "http://repo.eb.lan.at:80/artifactory/api/npm/npm-repo/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -10198,6 +10217,14 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "http://repo.eb.lan.at:80/artifactory/api/npm/npm-repo/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha1-wBUKI2ihgvAz6apRlex26kGhmcs=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -20721,6 +20748,16 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "http://repo.eb.lan.at:80/artifactory/api/npm/npm-repo/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -23144,6 +23181,13 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "http://repo.eb.lan.at:80/artifactory/api/npm/npm-repo/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -25601,6 +25645,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.17.0",
+      "resolved": "http://repo.eb.lan.at:80/artifactory/api/npm/npm-repo/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha1-wBUKI2ihgvAz6apRlex26kGhmcs=",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.3.4",

--- a/projects/controller/src/lib/meta-route-state-evaluation.ts
+++ b/projects/controller/src/lib/meta-route-state-evaluation.ts
@@ -1,0 +1,21 @@
+/**
+ * Defines how the meta router determines
+ * wheter the metaroute (microfronend) has a state (= dirty)
+ */
+export enum MetaRouteStateEvaluation {
+    /**
+     * Evaluates the state for the route. The metaroute
+     * will be reported dirty only if the active route has as state.
+     * The subRoute supplied to @see RoutedApp.changeState must
+     * always be the active route of the metaroute.
+     * This is the default evaluation.
+     */
+    RouteBased = 'RouteBased',
+    /**
+     * Evaluates the state for the entire metaroute. The metaroute
+     * will be reported dirty if any subroute has as state.
+     * The subRoute supplied to @see RoutedApp.changeState may
+     * be any string.
+     */
+    AppBased = 'AppBased'
+}

--- a/projects/controller/src/lib/meta-route-state-evaluation.ts
+++ b/projects/controller/src/lib/meta-route-state-evaluation.ts
@@ -1,6 +1,6 @@
 /**
  * Defines how the meta router determines
- * wheter the metaroute (microfronend) has a state (= dirty)
+ * whether the metaroute (microfronend) has a state (= dirty)
  */
 export enum MetaRouteStateEvaluation {
     /**

--- a/projects/controller/src/lib/meta-router.spec.ts
+++ b/projects/controller/src/lib/meta-router.spec.ts
@@ -457,6 +457,21 @@ describe('MetaRouter', async () => {
                 // Must reject using MetaRouteStateEvaluation.AppBased, because some route is dirty
                 await expectAsync(router.go('b')).toBeRejected();
             });
+
+            it('should not reject routing if when not route is dirty using MetaRouteStateEvaluation.AppBased', async () => {
+                await router.registerAllowStateDiscardCallbackAsync(async (metaroute: string) => {
+                    return Promise.resolve(false);
+                }, MetaRouteStateEvaluation.RouteBased);
+                await router.preload();
+
+                await router.go('a', 'myRoute');
+                const eventMock: EventListenerFacadeMock<MessageEvent> = provider.eventListenerFacadeMocks[EVENT_MESSAGE];
+                eventMock.simulateStateChangedMessage('a', false, 'myRoute');
+                eventMock.simulateStateChangedMessage('a', true, 'ToDoEditForm');
+
+                // Must reject using MetaRouteStateEvaluation.AppBased, because some route is dirty
+                await expectAsync(router.go('b', 'newRoute')).toBeResolved();
+            });
         });
     });
 });

--- a/projects/controller/src/lib/microfrontend-states.spec.ts
+++ b/projects/controller/src/lib/microfrontend-states.spec.ts
@@ -29,13 +29,24 @@ describe('MicrofrontendStates', async () => {
         expect(mfStates.hasState(missingRoute)).toBeFalse();
     });
 
-    it('should check microfrontend states with subroute correctly', () => {
+    // Not supported anymore; not required
+    // it('should check microfrontend states with subroute correctly', () => {
+    //     const mfStates = new MicrofrontendStates();
+    //     const route = new AppRoute('b');
+    //     mfStates.setState(route, true);
+    //     const missingRoute1 = new AppRoute('b', 'x');
+    //     expect(mfStates.hasState(missingRoute1)).toBeFalse();
+    //     const missingRoute2 = new AppRoute('b', 'y');
+    //     expect(mfStates.hasState(missingRoute2)).toBeFalse();
+    // });
+
+    it('should check for multiple states correctly', () => {
+        const metaRoute = 'a';
         const mfStates = new MicrofrontendStates();
-        const route = new AppRoute('b');
-        mfStates.setState(route, true);
-        const missingRoute1 = new AppRoute('b', 'x');
-        expect(mfStates.hasState(missingRoute1)).toBeFalse();
-        const missingRoute2 = new AppRoute('b', 'y');
-        expect(mfStates.hasState(missingRoute2)).toBeFalse();
+
+        mfStates.setState(new AppRoute(metaRoute, 'CustomerEditForm'), false);
+        mfStates.setState(new AppRoute(metaRoute, 'CustomerAddressEditForm'), true);
+
+        expect(mfStates.hasState(new AppRoute(metaRoute))).toBeTrue();
     });
 });

--- a/projects/controller/src/lib/microfrontend-states.spec.ts
+++ b/projects/controller/src/lib/microfrontend-states.spec.ts
@@ -1,4 +1,5 @@
 import { AppRoute } from './app-route';
+import { MetaRouteStateEvaluation } from './meta-route-state-evaluation';
 import { MicrofrontendStates } from './microfrontend-states';
 
 describe('MicrofrontendStates', async () => {
@@ -29,16 +30,15 @@ describe('MicrofrontendStates', async () => {
         expect(mfStates.hasState(missingRoute)).toBeFalse();
     });
 
-    // Not supported anymore; not required
-    // it('should check microfrontend states with subroute correctly', () => {
-    //     const mfStates = new MicrofrontendStates();
-    //     const route = new AppRoute('b');
-    //     mfStates.setState(route, true);
-    //     const missingRoute1 = new AppRoute('b', 'x');
-    //     expect(mfStates.hasState(missingRoute1)).toBeFalse();
-    //     const missingRoute2 = new AppRoute('b', 'y');
-    //     expect(mfStates.hasState(missingRoute2)).toBeFalse();
-    // });
+    it('should check microfrontend states with subroute correctly', () => {
+        const mfStates = new MicrofrontendStates();
+        const route = new AppRoute('b');
+        mfStates.setState(route, true);
+        const missingRoute1 = new AppRoute('b', 'x');
+        expect(mfStates.hasState(missingRoute1)).toBeFalse();
+        const missingRoute2 = new AppRoute('b', 'y');
+        expect(mfStates.hasState(missingRoute2)).toBeFalse();
+    });
 
     it('should check for multiple states correctly', () => {
         const metaRoute = 'a';
@@ -47,6 +47,9 @@ describe('MicrofrontendStates', async () => {
         mfStates.setState(new AppRoute(metaRoute, 'CustomerEditForm'), false);
         mfStates.setState(new AppRoute(metaRoute, 'CustomerAddressEditForm'), true);
 
-        expect(mfStates.hasState(new AppRoute(metaRoute))).toBeTrue();
+        // If querying route based this must return false as this route is not dirty
+        expect(mfStates.hasState(new AppRoute(metaRoute, 'x'), MetaRouteStateEvaluation.RouteBased)).toBeFalse();
+        // If querying app based this must return true as *some* route is dirty
+        expect(mfStates.hasState(new AppRoute(metaRoute, 'x'), MetaRouteStateEvaluation.AppBased)).toBeTrue();
     });
 });

--- a/projects/controller/src/lib/microfrontend-states.ts
+++ b/projects/controller/src/lib/microfrontend-states.ts
@@ -7,29 +7,18 @@ import { AppRoute } from './app-route';
  */
 export class MicrofrontendStates {
     /** Key to use is subRoute is missing */
-    private static emptySubrouteKey = '';
+    private static readonly emptySubrouteKey = '';
 
     /** Last reported microfrontend state */
-    private microfrontendsStates: IMap<IMap<boolean>> = {};
+    private readonly microfrontendsStates: IMap<IMap<boolean>> = {};
 
     /**
      * Check if route has state that might get lost set
      */
-     public hasState(route: AppRoute): boolean {
+    public hasState(route: AppRoute): boolean {
         if (this.microfrontendsStates.hasOwnProperty(route.metaRoute)) {
-            if (route.subRoute) {
-                if (this.microfrontendsStates[route.metaRoute].hasOwnProperty(route.subRoute)) {
-                    if (this.microfrontendsStates[route.metaRoute][route.subRoute]) {
-                        return true;
-                    } else {
-                        return false;
-                    }
-                }
-            } else {
-                if (this.microfrontendsStates[route.metaRoute][MicrofrontendStates.emptySubrouteKey]) {
-                    return true;
-                }
-            }
+            // Check if metaroute has any dirty state
+            return Object.values(this.microfrontendsStates[route.metaRoute]).some((hasState) => hasState);
         }
         return false;
     }
@@ -37,11 +26,13 @@ export class MicrofrontendStates {
     /**
      * Check if route has state set that might get lost
      */
-     public setState(route: AppRoute, hasState: boolean): void {
+    public setState(route: AppRoute, hasState: boolean): void {
         if (!this.microfrontendsStates.hasOwnProperty(route.metaRoute)) {
             this.microfrontendsStates[route.metaRoute] = {};
         }
 
+        // The subRoute may be any string and must not correspond
+        // to a valid application route.
         if (route.subRoute) {
             this.microfrontendsStates[route.metaRoute][route.subRoute] = hasState;
         } else {

--- a/projects/controller/src/mocks/event-listener-facade.mock.ts
+++ b/projects/controller/src/mocks/event-listener-facade.mock.ts
@@ -2,13 +2,13 @@ import {
     Destroyable,
     EventListenerNotificationAsync,
     IMap,
+    MessageBroadcastMetadata,
     MESSAGE_BROADCAST,
     MESSAGE_GOTO,
+    MESSAGE_META_ROUTED,
     MESSAGE_ROUTED,
     MESSAGE_SET_FRAME_STYLES,
-    MESSAGE_META_ROUTED,
-    MESSAGE_STATE_CHANGED,
-    MessageBroadcastMetadata
+    MESSAGE_STATE_CHANGED
 } from '@microfrontend/common';
 import { MESSAGE_GET_CUSTOM_FRAME_CONFIG } from 'projects/common/src/lib/constants';
 
@@ -24,9 +24,9 @@ export class EventListenerFacadeMock<T extends Event> extends Destroyable {
         return this.notificationHandler(<T>e);
     }
 
-    simulateStateChangedMessage(source: string, hasState: boolean): Promise<void> {
+    simulateStateChangedMessage(source: string, hasState: boolean, subRoute?: string): Promise<void> {
         const e: unknown = {
-            data: { message: MESSAGE_STATE_CHANGED, source: source, hasState: hasState },
+            data: { message: MESSAGE_STATE_CHANGED, source: source, hasState: hasState, subRoute: subRoute },
             origin: origin
         };
         return this.notificationHandler(<T>e);


### PR DESCRIPTION
RoutedApp.ChangeState() can be called with any "subRoute" which usually describes the entity/form which is currently being edited. 
If microfrontend checks for dirty state it always checks the *the current application route*. However it should check if *any* of the previously changed states is dirty.

Example: 
- current metaroute is 'a', route is 'customer'
- route has 2 edit forms, one is dirty

`routedApp.changeState(false, 'CustomerEditForm')`
`routedApp.changeState(true, 'CustomerAddressEditForm')`

--> registerAllowStateDiscardCallbackAsync() is not triggering because hasState()-Check is performed with route ('customer')
